### PR TITLE
Fix ZeroHeuristic docstring typo

### DIFF
--- a/RushHourProject.ipynb
+++ b/RushHourProject.ipynb
@@ -266,7 +266,7 @@
         "    pass\n",
         "\n",
         "class ZeroHeuristic:\n",
-        "    \"\"\"Zero Heuristcs, same as a BFS search\"\"\"\n",
+        "    \"\"\"Zero Heuristics, same as a BFS search.\"\"\"\n",
         "\n",
         "    def calculate(self, board):\n",
         "        return 0\n",


### PR DESCRIPTION
## Summary
- correct typo in `ZeroHeuristic` docstring

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b9569fd40832a870296c2c2965081